### PR TITLE
fix: make view methods pausable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ keywords = ["near", "smart contract", "plugin"]
 
 [workspace.dependencies]
 bitflags = "1.3"
-near-sdk = "5.2"
+near-sdk = "=5.2"
 near-plugins = { path = "near-plugins" }
 near-plugins-derive = { path = "near-plugins-derive" }
 serde = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ keywords = ["near", "smart contract", "plugin"]
 
 [workspace.dependencies]
 bitflags = "1.3"
-near-sdk = "=5.2"
+near-sdk = ">=5.2, <5.4"
 near-plugins = { path = "near-plugins" }
 near-plugins-derive = { path = "near-plugins-derive" }
 serde = "1"

--- a/near-plugins-derive/src/pausable.rs
+++ b/near-plugins-derive/src/pausable.rs
@@ -201,16 +201,20 @@ pub fn if_paused(attrs: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn get_bypass_condition(args: &ExceptSubArgs) -> proc_macro2::TokenStream {
-    let except_roles = args.roles.clone();
-    quote!(
-        let __except_roles: Vec<&str> = vec![#(#except_roles.into()),*];
-        let __except_roles: Vec<String> = __except_roles.iter().map(|&x| x.into()).collect();
-        let may_bypass = self.acl_has_any_role(
-            __except_roles,
-            ::near_sdk::env::predecessor_account_id()
-        );
-        if may_bypass {
-            __check_paused = false;
-        }
-    )
+    if args.roles.len() > 0 {
+        let except_roles = args.roles.clone();
+        quote!(
+            let __except_roles: Vec<&str> = vec![#(#except_roles.into()),*];
+            let __except_roles: Vec<String> = __except_roles.iter().map(|&x| x.into()).collect();
+            let may_bypass = self.acl_has_any_role(
+                __except_roles,
+                ::near_sdk::env::predecessor_account_id()
+            );
+            if may_bypass {
+                __check_paused = false;
+            }
+        )
+    } else {
+        quote!()
+    }
 }

--- a/near-plugins-derive/src/pausable.rs
+++ b/near-plugins-derive/src/pausable.rs
@@ -201,20 +201,20 @@ pub fn if_paused(attrs: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn get_bypass_condition(args: &ExceptSubArgs) -> proc_macro2::TokenStream {
-    if args.roles.len() > 0 {
-        let except_roles = args.roles.clone();
-        quote!(
-            let __except_roles: Vec<&str> = vec![#(#except_roles.into()),*];
-            let __except_roles: Vec<String> = __except_roles.iter().map(|&x| x.into()).collect();
-            let may_bypass = self.acl_has_any_role(
-                __except_roles,
-                ::near_sdk::env::predecessor_account_id()
-            );
-            if may_bypass {
-                __check_paused = false;
-            }
-        )
-    } else {
-        quote!()
+    if args.roles.len() == 0 {
+        return quote!();
     }
+
+    let except_roles = args.roles.clone();
+    quote!(
+        let __except_roles: Vec<&str> = vec![#(#except_roles.into()),*];
+        let __except_roles: Vec<String> = __except_roles.iter().map(|&x| x.into()).collect();
+        let may_bypass = self.acl_has_any_role(
+            __except_roles,
+            ::near_sdk::env::predecessor_account_id()
+        );
+        if may_bypass {
+            __check_paused = false;
+        }
+    )
 }

--- a/near-plugins-derive/tests/common/utils.rs
+++ b/near-plugins-derive/tests/common/utils.rs
@@ -110,6 +110,16 @@ pub fn assert_method_is_paused(res: ExecutionFinalResult) {
     );
 }
 
+pub fn assert_view_method_is_paused(err: anyhow::Error) {
+    let err = format!("{:?}", err);
+    let must_contain = "Pausable: Method is paused";
+    assert!(
+        err.contains(must_contain),
+        "Expected method to be paused, instead it failed with: {}",
+        err
+    );
+}
+
 pub fn assert_pausable_escape_hatch_is_closed(res: ExecutionFinalResult, feature: &str) {
     let must_contain = format!("Pausable: {feature} must be paused to use this function");
     assert_failure_with(res, &must_contain);

--- a/near-plugins-derive/tests/contracts/pausable/src/lib.rs
+++ b/near-plugins-derive/tests/contracts/pausable/src/lib.rs
@@ -57,6 +57,7 @@ impl Counter {
     }
 
     /// Returns the value of the counter.
+    #[pause]
     pub fn get_counter(&self) -> u64 {
         self.counter
     }

--- a/near-plugins-derive/tests/pausable.rs
+++ b/near-plugins-derive/tests/pausable.rs
@@ -342,6 +342,18 @@ async fn test_not_paused_with_different_key() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn test_view_call_of_pausable_method() -> anyhow::Result<()> {
+    let setup = Setup::new().await?;
+    let res = setup
+        .call_counter_modifier(&setup.unauth_account, "increase_1")
+        .await?;
+    assert_success_with_unit_return(res);
+    assert_eq!(setup.get_counter().await?, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_work_after_unpause() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
 

--- a/near-plugins-derive/tests/pausable.rs
+++ b/near-plugins-derive/tests/pausable.rs
@@ -7,6 +7,7 @@ use common::pausable_contract::PausableContract;
 use common::utils::{
     assert_failure_with, assert_insufficient_acl_permissions, assert_method_is_paused,
     assert_pausable_escape_hatch_is_closed, assert_success_with, assert_success_with_unit_return,
+    assert_view_method_is_paused,
 };
 use near_sdk::serde_json::json;
 use near_workspaces::network::Sandbox;
@@ -319,6 +320,11 @@ async fn test_pause_with_all_allows_except() -> anyhow::Result<()> {
         .call_counter_modifier(&exempted_account, "increase_4")
         .await?;
     assert_success_with_unit_return(res);
+    let res = setup
+        .pausable_contract
+        .pa_unpause_feature(&setup.pause_manager, "ALL")
+        .await?;
+    assert_success_with(res, true);
     assert_eq!(setup.get_counter().await?, 4);
     Ok(())
 }
@@ -342,13 +348,20 @@ async fn test_not_paused_with_different_key() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_view_call_of_pausable_method() -> anyhow::Result<()> {
+async fn test_pause_view_method() -> anyhow::Result<()> {
     let setup = Setup::new().await?;
     let res = setup
         .call_counter_modifier(&setup.unauth_account, "increase_1")
         .await?;
     assert_success_with_unit_return(res);
     assert_eq!(setup.get_counter().await?, 1);
+
+    let res = setup
+        .pausable_contract
+        .pa_pause_feature(&setup.pause_manager, "get_counter")
+        .await?;
+    assert_success_with(res, true);
+    assert_view_method_is_paused(setup.get_counter().await.unwrap_err());
 
     Ok(())
 }


### PR DESCRIPTION
- Skip role verifications if the pausable method doesn't contain except roles to able to call view methods.
- Fix the `near-sdk` version to avoid auto upgrade that breaks CI and build due to dependencies conflicts.