### PR TITLE
fix: remove the limit on minor version from `near-sdk` dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   RUST_BACKTRACE: full
-  MSRV: 1.76.0
+  MSRV: 1.79.0
 
 jobs:
   tests:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ keywords = ["near", "smart contract", "plugin"]
 
 [workspace.dependencies]
 bitflags = "1.3"
-near-sdk = ">=5.2"
+near-sdk = ">=5.4"
 near-plugins = { path = "near-plugins" }
 near-plugins-derive = { path = "near-plugins-derive" }
 serde = "1"
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
-near-workspaces = "0.11"
+near-workspaces = "0.14"
 toml = "0.8"
 darling = "0.13.1"
 proc-macro2 = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ keywords = ["near", "smart contract", "plugin"]
 
 [workspace.dependencies]
 bitflags = "1.3"
-near-sdk = ">=5.2, <5.4"
+near-sdk = ">=5.2"
 near-plugins = { path = "near-plugins" }
 near-plugins-derive = { path = "near-plugins-derive" }
 serde = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ keywords = ["near", "smart contract", "plugin"]
 
 [workspace.dependencies]
 bitflags = "1.3"
-near-sdk = ">=5.4"
+near-sdk = ">=5.2"
 near-plugins = { path = "near-plugins" }
 near-plugins-derive = { path = "near-plugins-derive" }
 serde = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Aurora Labs <hello@aurora.dev>"]
 # An update of the MSRV requires updating:
 # - `rust-toolchain` files in `near-plugins-derive/tests/contracts/**`
 # - the toolchain installed in CI via the `toolchain` parameter of `actions-rs/toolchain@v1`
-rust-version = "1.76.0"
+rust-version = "1.79.0"
 description = "Ergonomic plugin system to extend NEAR contracts."
 license = "CC0-1.0"
 readme = "README.md"

--- a/near-plugins-derive/tests/contracts/access_controllable/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/access_controllable/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.79.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/contracts/ownable/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/ownable/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.79.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/contracts/pausable/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/pausable/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.79.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/contracts/upgradable/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/upgradable/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.79.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/contracts/upgradable_2/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/upgradable_2/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.79.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/contracts/upgradable_state_migration/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/upgradable_state_migration/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.79.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Hey Team!
This PR removes limitation on the minor version of `near-sdk` as it prevents people from updating `near-sdk` to the latest version, while the real version pinning should be done in `Cargo.lock` for every binary crate, IMHO