### PR TITLE
fix: ABI generation

### DIFF
--- a/near-plugins/src/access_controllable.rs
+++ b/near-plugins/src/access_controllable.rs
@@ -35,8 +35,7 @@
 //! Inspired by OpenZeppelin's
 //! [AccessControl](https://docs.openzeppelin.com/contracts/3.x/api/access#AccessControl) module.
 
-use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::AccountId;
+use near_sdk::{AccountId, near, serde::{Deserialize, Serialize}};
 use std::collections::HashMap;
 
 /// # Representation of roles
@@ -399,7 +398,8 @@ pub trait AccessControllable {
 /// # Uniqueness and ordering
 ///
 /// Account ids returned in vectors are unique but not ordered.
-#[derive(Deserialize, Serialize, Debug)]
+#[near(serializers = [json])]
+#[derive(Debug)]
 pub struct PermissionedAccounts {
     /// The accounts that have super admin permissions.
     pub super_admins: Vec<AccountId>,
@@ -412,7 +412,8 @@ pub struct PermissionedAccounts {
 /// # Uniqueness and ordering
 ///
 /// Account ids returned in vectors are unique but not ordered.
-#[derive(Deserialize, Serialize, Debug)]
+#[near(serializers = [json])]
+#[derive(Debug)]
 pub struct PermissionedAccountsPerRole {
     /// The accounts that have admin permissions for the role.
     pub admins: Vec<AccountId>,

--- a/near-plugins/src/access_controllable.rs
+++ b/near-plugins/src/access_controllable.rs
@@ -35,7 +35,7 @@
 //! Inspired by OpenZeppelin's
 //! [AccessControl](https://docs.openzeppelin.com/contracts/3.x/api/access#AccessControl) module.
 
-use near_sdk::{AccountId, near, serde::{Deserialize, Serialize}};
+use near_sdk::{near, AccountId};
 use std::collections::HashMap;
 
 /// # Representation of roles

--- a/near-plugins/src/upgradable.rs
+++ b/near-plugins/src/upgradable.rs
@@ -60,8 +60,7 @@
 //! [batch transaction]: https://docs.near.org/concepts/basics/transactions/overview
 //! [time between scheduling and execution]: https://docs.near.org/sdk/rust/promises/intro
 use crate::events::{AsEvent, EventMetadata};
-use near_sdk::serde::{Deserialize, Serialize};
-use near_sdk::{AccountId, CryptoHash, Gas, NearToken, Promise};
+use near_sdk::{near, serde::Serialize, AccountId, CryptoHash, Gas, NearToken, Promise};
 
 /// Trait describing the functionality of the _Upgradable_ plugin.
 pub trait Upgradable {
@@ -197,7 +196,7 @@ pub trait Upgradable {
     fn up_apply_update_staging_duration(&mut self);
 }
 
-#[derive(Deserialize, Serialize)]
+#[near(serializers = [json])]
 pub struct UpgradableDurationStatus {
     pub staging_duration: Option<near_sdk::Duration>,
     pub staging_timestamp: Option<near_sdk::Timestamp>,
@@ -207,7 +206,8 @@ pub struct UpgradableDurationStatus {
 
 /// Specifies a function call to be appended to the actions of a promise via
 /// [`near_sdk::Promise::function_call`]).
-#[derive(Deserialize, Serialize, Debug)]
+#[near(serializers = [json])]
+#[derive(Debug)]
 pub struct FunctionCallArgs {
     /// The name of the function to call.
     pub function_name: String,


### PR DESCRIPTION
This PR fixes an issue when ABI generation fails due to absence of `#[derive(JsonSchema)]`
```sh
cargo near build
# ...
• Generating ABI
 │ error[E0277]: the trait bound `PermissionedAccounts: JsonSchema` is not satisfied
 │     |
 │ 18  | #[access_control(role_type(Role))]
 │     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 │     | |
 │     | the trait `JsonSchema` is not implemented for `PermissionedAccounts`
 │     | required by a bound introduced by this call
 │     |
 │     = help: the following other types implement trait `JsonSchema`:
 │               &'a T
 │               &'a mut T
 │               ()
 │               (T0, T1)
 │               (T0, T1, T2)
 │               (T0, T1, T2, T3)
 │               (T0, T1, T2, T3, T4)
 │               (T0, T1, T2, T3, T4, T5)
 │             and 185 others
 │ note: required by a bound in `SchemaGenerator::subschema_for`
 │    --> /Users/mitinarseny/.cargo/registry/src/index.crates.io-6f17d22bba15001f/schemars-0.8.21/src/gen.rs:221:38
 │     |
 │ 221 |     pub fn subschema_for<T: ?Sized + JsonSchema>(&mut self) -> Schema {
 │     |                                      ^^^^^^^^^^ required by this bound in `SchemaGenerator::subschema_for`
 │     = note: this error originates in the attribute macro `access_control` (in Nightly builds, run with -Z macro-backtrace for more info)
 │ 
 │ For more information about this error, try `rustc --explain E0277`.
 │ error: could not compile `defuse-contract` (lib) due to 1 previous error
```

Basically, in order to properly handle ABI generation via `cargo near`, you're literally forced to use `#[near(serializers = [json])]`, as its expanded version [depends](https://github.com/near/near-sdk-rs/blob/f179a289528fbec5cd85077314e29deec198d0f3/near-sdk-macros/src/lib.rs#L184-L192) on `near-sdk/abi` feature, so you can think of expanded version as:
```rust
#[derive(::near_sdk::serde::Deserialize, ::near_sdk::serde::Serialize)]
#[serde(crate = "::near_sdk::serde")]
#[cfg_attr(all(feature = "near_sdk/abi", not(target_arch = "wasm32")), derive(::near_sdk::schemars::JsonSchema))]
#[cfg_attr(all(feature = "near_sdk/abi", not(target_arch = "wasm32")), schemars(crate = "::near_sdk::schemars"))]
```