### PR TITLE
feat: make the upgrade process safer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   RUST_BACKTRACE: full
-  MSRV: 1.79.0
+  MSRV: 1.80.0
 
 jobs:
   tests:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Aurora Labs <hello@aurora.dev>"]
 # An update of the MSRV requires updating:
 # - `rust-toolchain` files in `near-plugins-derive/tests/contracts/**`
 # - the toolchain installed in CI via the `toolchain` parameter of `actions-rs/toolchain@v1`
-rust-version = "1.79.0"
+rust-version = "1.80.0"
 description = "Ergonomic plugin system to extend NEAR contracts."
 license = "CC0-1.0"
 readme = "README.md"

--- a/near-plugins-derive/src/upgradable.rs
+++ b/near-plugins-derive/src/upgradable.rs
@@ -226,9 +226,7 @@ pub fn derive_upgradable(input: TokenStream) -> TokenStream {
                 }
             }
 
-            fn up_verify_state(&self) -> bool {
-                true
-            }
+            fn up_verify_state(&self) {}
 
             #[#cratename::access_control_any(roles(#(#acl_roles_duration_initializers),*))]
             fn up_init_staging_duration(&mut self, staging_duration: ::near_sdk::Duration) {

--- a/near-plugins-derive/src/upgradable.rs
+++ b/near-plugins-derive/src/upgradable.rs
@@ -216,7 +216,7 @@ pub fn derive_upgradable(input: TokenStream) -> TokenStream {
                 let promise = ::near_sdk::Promise::new(::near_sdk::env::current_account_id())
                     .deploy_contract(code);
                 match function_call_args {
-                    None => promise,
+                    None => promise.function_call("up_verify_state".to_owned(), vec![], near_sdk::NearToken::from_yoctonear(0), near_sdk::Gas::from_tgas(2)),
                     Some(args) => {
                         // Execute the `DeployContract` and `FunctionCall` actions in a batch
                         // transaction to make a failure of the function call roll back the code
@@ -224,6 +224,10 @@ pub fn derive_upgradable(input: TokenStream) -> TokenStream {
                         promise.function_call(args.function_name, args.arguments, args.amount, args.gas)
                     },
                 }
+            }
+
+            fn up_verify_state(&self) -> bool {
+                true
             }
 
             #[#cratename::access_control_any(roles(#(#acl_roles_duration_initializers),*))]

--- a/near-plugins-derive/tests/contracts/access_controllable/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/access_controllable/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/contracts/ownable/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/ownable/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/contracts/pausable/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/pausable/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/contracts/upgradable/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/upgradable/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/contracts/upgradable_2/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/upgradable_2/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/contracts/upgradable_state_migration/rust-toolchain
+++ b/near-plugins-derive/tests/contracts/upgradable_state_migration/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 components = ["clippy", "rustfmt"]
 targets = [ "wasm32-unknown-unknown" ]

--- a/near-plugins-derive/tests/upgradable.rs
+++ b/near-plugins-derive/tests/upgradable.rs
@@ -672,11 +672,7 @@ async fn test_deploy_code_with_missed_migration() -> anyhow::Result<()> {
     // Deploy staged code
     let res = setup
         .upgradable_contract
-        .up_deploy_code(
-            &dao,
-            convert_code_to_deploy_hash(&code),
-            None,
-        )
+        .up_deploy_code(&dao, convert_code_to_deploy_hash(&code), None)
         .await?;
     assert_failure_with(res, "Cannot deserialize the contract state");
 

--- a/near-plugins-derive/tests/upgradable.rs
+++ b/near-plugins-derive/tests/upgradable.rs
@@ -438,7 +438,7 @@ async fn test_deploy_code_without_delay() -> anyhow::Result<()> {
     let setup = Setup::new(worker.clone(), Some(dao.id().clone()), None).await?;
 
     // Stage some code.
-    let code = vec![1, 2, 3];
+    let code = common::repo::compile_project(Path::new(PROJECT_PATH), "upgradable").await?;
     let res = setup
         .upgradable_contract
         .up_stage_code(&dao, code.clone())
@@ -463,7 +463,7 @@ async fn test_deploy_code_with_hash_success() -> anyhow::Result<()> {
     let setup = Setup::new(worker.clone(), Some(dao.id().clone()), None).await?;
 
     // Stage some code.
-    let code = vec![1, 2, 3];
+    let code = common::repo::compile_project(Path::new(PROJECT_PATH), "upgradable").await?;
     let res = setup
         .upgradable_contract
         .up_stage_code(&dao, code.clone())
@@ -491,7 +491,7 @@ async fn test_deploy_code_with_hash_invalid_hash() -> anyhow::Result<()> {
     let setup = Setup::new(worker.clone(), Some(dao.id().clone()), None).await?;
 
     // Stage some code.
-    let code = vec![1, 2, 3];
+    let code = common::repo::compile_project(Path::new(PROJECT_PATH), "upgradable").await?;
     let res = setup
         .upgradable_contract
         .up_stage_code(&dao, code.clone())
@@ -712,7 +712,7 @@ async fn test_deploy_code_in_batch_transaction_pitfall() -> anyhow::Result<()> {
     // Construct the function call actions to be executed in a batch transaction.
     // Note that we are attaching a call to `migrate_with_failure`, which will fail.
     let fn_call_deploy = near_workspaces::operations::Function::new("up_deploy_code")
-        .args_json(json!({ 
+        .args_json(json!({
             "hash": convert_code_to_deploy_hash(&code),
             "function_call_args": FunctionCallArgs {
         function_name: "migrate_with_failure".to_string(),
@@ -770,7 +770,7 @@ async fn test_deploy_code_with_delay() -> anyhow::Result<()> {
     .await?;
 
     // Stage some code.
-    let code = vec![1, 2, 3];
+    let code = common::repo::compile_project(Path::new(PROJECT_PATH), "upgradable").await?;
     let res = setup
         .upgradable_contract
         .up_stage_code(&dao, code.clone())
@@ -803,7 +803,7 @@ async fn test_deploy_code_with_delay_failure_too_early() -> anyhow::Result<()> {
     .await?;
 
     // Stage some code.
-    let code = vec![1, 2, 3];
+    let code = common::repo::compile_project(Path::new(PROJECT_PATH), "upgradable").await?;
     let res = setup
         .upgradable_contract
         .up_stage_code(&dao, code.clone())

--- a/near-plugins/src/access_controllable.rs
+++ b/near-plugins/src/access_controllable.rs
@@ -192,7 +192,7 @@ pub trait AccessControllable {
     ///    }
     /// }
     /// ```
-    ///     
+    ///
     /// ```json
     /// {
     ///    "standard":"AccessControllable",
@@ -356,7 +356,7 @@ pub trait AccessControllable {
     ///
     /// * Get roles with [`Self::acl_get_roles`].
     /// * Get (a subset) of permissioned accounts with [`Self::acl_get_super_admins`],
-    /// [`Self::acl_get_admins`], or [`Self::acl_get_grantees`].
+    ///   [`Self::acl_get_admins`], or [`Self::acl_get_grantees`].
     ///
     /// [gas limit]: https://github.com/near/nearcore/pull/4381
     fn acl_get_permissioned_accounts(&self) -> PermissionedAccounts;

--- a/near-plugins/src/upgradable.rs
+++ b/near-plugins/src/upgradable.rs
@@ -194,6 +194,9 @@ pub trait Upgradable {
     /// attribute. The example contract (accessible via the `README`) shows how access control roles
     /// can be defined and passed on to the `Upgradable` macro.
     fn up_apply_update_staging_duration(&mut self);
+
+    /// Returns true if the contract state is valid, panic otherwise.
+    fn up_verify_state(&self) -> bool;
 }
 
 #[near(serializers = [json])]

--- a/near-plugins/src/upgradable.rs
+++ b/near-plugins/src/upgradable.rs
@@ -195,8 +195,8 @@ pub trait Upgradable {
     /// can be defined and passed on to the `Upgradable` macro.
     fn up_apply_update_staging_duration(&mut self);
 
-    /// Returns true if the contract state is valid, panic otherwise.
-    fn up_verify_state(&self) -> bool;
+    /// Panic if state is not valid.
+    fn up_verify_state(&self);
 }
 
 #[near(serializers = [json])]


### PR DESCRIPTION
If the migration is missed during the upgrade, it cannot be recovered. Therefore, the contract state will be corrupted, and the upgrade cannot be repeated.
There are two ways to prevent this:
- Remove the `self` everywhere from the near-plugins [example](https://github.com/Near-One/near-plugins/commit/8a354743525806671061aae2e6833836a91ec7e0).
- Verify the state after migration by default.

The second one is less invasive, so this PR implements it.