### PR TITLE
feat: Separate pause and unpause roles in Pausable plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.3.0 (TBD)
+
+## BREAKING CHANGES:
+
+### Pausable Plugin
+
+- Replaced the combined `manager_roles` attribute with separate `pause_roles` and `unpause_roles` attributes for the `Pausable` plugin.
+- This allows for separate permissions for pausing and unpausing features, enabling more granular access control.
+
+To migrate from the previous version:
+```rust
+// Old format
+#[pausable(manager_roles(Role::PauseManager))]
+
+// New format
+#[pausable(
+    pause_roles(Role::PauseManager),
+    unpause_roles(Role::UnpauseManager) 
+)]
+```
+
+See the [migration guide](docs/migrations/pausable-separate-roles.md) for more details.
+
+
 # 0.2.0 (TBD)
 
 ## BREAKING CHANGES:

--- a/docs/migrations/pausable-separate-roles.md
+++ b/docs/migrations/pausable-separate-roles.md
@@ -1,0 +1,114 @@
+# Migrating to Separate Pause/Unpause Roles
+
+This guide explains how to migrate your code to use the new `pause_roles` and `unpause_roles` attributes instead of the consolidated `manager_roles` attribute in the Pausable plugin.
+
+## Changes Required
+
+### Before
+
+Previously, you would define permissions for both pausing and unpausing using a single attribute:
+
+```rust
+#[pausable(manager_roles(Role::PauseManager))]
+struct Contract {
+    // Contract fields
+}
+```
+
+This meant that any account with the `PauseManager` role could both pause and unpause features.
+
+### After
+
+Now, you need to specify permissions for pausing and unpausing separately:
+
+```rust
+#[pausable(
+    pause_roles(Role::PauseManager),
+    unpause_roles(Role::UnpauseManager)
+)]
+struct Contract {
+    // Contract fields
+}
+```
+
+With this change, you can:
+- Grant an account only the ability to pause features (emergency response)
+- Grant a different account only the ability to unpause features (recovery process)
+- Grant some accounts both abilities
+
+## Step-by-Step Migration
+
+1. **Update your Role enum** to include separate roles for pausing and unpausing, if desired:
+
+   ```rust
+   #[derive(AccessControlRole, Deserialize, Serialize, Copy, Clone)]
+   #[serde(crate = "near_sdk::serde")]
+   pub enum Role {
+       // Previous role that could both pause and unpause
+       // PauseManager,
+       
+       // New separate roles
+       PauseManager,   // Can only pause features
+       UnpauseManager, // Can only unpause features
+       // Other roles...
+   }
+   ```
+
+2. **Update the pausable attribute** to use the new format:
+
+   ```rust
+   // Old format
+   // #[pausable(manager_roles(Role::PauseManager))]
+   
+   // New format
+   #[pausable(
+       pause_roles(Role::PauseManager),
+       unpause_roles(Role::UnpauseManager)
+   )]
+   ```
+
+3. **Update contract initialization** to grant the appropriate roles:
+
+   ```rust
+   #[init]
+   pub fn new(pause_manager: AccountId, unpause_manager: AccountId) -> Self {
+       let mut contract = Self { 
+           // contract fields 
+       };
+       
+       // Make the contract itself super admin
+       contract.acl_init_super_admin(env::current_account_id());
+       
+       // Grant pause role
+       contract.acl_grant_role(Role::PauseManager.into(), pause_manager);
+       
+       // Grant unpause role (might be the same or different account)
+       contract.acl_grant_role(Role::UnpauseManager.into(), unpause_manager);
+       
+       contract
+   }
+   ```
+
+4. **Update tests** to test both pause and unpause permissions separately.
+
+## Example
+
+Here's a complete example of a contract using the new separated roles:
+
+```rust
+#[access_control(role_type(Role))]
+#[near(contract_state)]
+#[derive(Pausable, PanicOnDefault)]
+#[pausable(
+    pause_roles(Role::PauseManager, Role::EmergencyPauser),
+    unpause_roles(Role::UnpauseManager, Role::ServiceRestorer)
+)]
+pub struct Counter {
+    counter: u64,
+}
+```
+
+In this example:
+- Accounts with either `PauseManager` or `EmergencyPauser` roles can pause features
+- Accounts with either `UnpauseManager` or `ServiceRestorer` roles can unpause features
+- An account might have multiple roles (e.g., both pause and unpause capabilities)

--- a/near-plugins/src/pausable.rs
+++ b/near-plugins/src/pausable.rs
@@ -49,7 +49,7 @@ pub trait Pausable {
     fn pa_all_paused(&self) -> Option<HashSet<String>>;
 
     /// Pauses feature `key`. This method fails if the caller has not been granted one of the access
-    /// control `manager_roles` passed to the `Pausable` plugin.
+    /// control `pause_roles` passed to the `Pausable` plugin.
     ///
     /// It returns `true` if the feature is paused as a result of this function call and `false` if
     /// the feature was already paused. In either case, the feature is paused after the function
@@ -73,7 +73,7 @@ pub trait Pausable {
     fn pa_pause_feature(&mut self, key: String) -> bool;
 
     /// Unpauses feature `key`. This method fails if the caller has not been granted one of the
-    /// access control `manager_roles` passed to the `Pausable` plugin.
+    /// access control `unpause_roles` passed to the `Pausable` plugin.
     ///
     /// It returns whether the feature was paused, i.e. `true` if the feature was paused and
     /// otherwise `false`. In either case, the feature is unpaused after the function returns


### PR DESCRIPTION
Replaces the single `manager_roles` attribute with separate `pause_roles` and `unpause_roles` attributes in the Pausable plugin. This enables assigning different permissions for pausing and unpausing features.

## Implementation

- Modified `pausable.rs` trait and implementation to support separate role specifications
- Updated test contracts and tests
- Added migration documentation and CHANGELOG entry

## Usage

```rust
// Before
#[pausable(manager_roles(Role::PauseManager))]

// After
#[pausable(
    pause_roles(Role::PauseManager),
    unpause_roles(Role::UnpauseManager)
)]
```

## Impact

Breaking change that requires code updates when upgrading. This enables more granular security policies, particularly in scenarios where emergency pausing should be available to more accounts than unpausing.

- Closes #151
- Closes #124